### PR TITLE
Restore sketch-only mask selection handling

### DIFF
--- a/scripts/inpaint_anything.py
+++ b/scripts/inpaint_anything.py
@@ -219,10 +219,23 @@ def select_mask(input_image, sam_image, invert_chk, ignore_black_chk, sel_mask):
         return ret_sel_mask
     sam_masks = sam_dict["sam_masks"]
 
-    # image = sam_image["image"]
-    mask = sam_image.get("mask")
+    mask = None
+
+    if isinstance(sam_image, dict):
+        mask = sam_image.get("mask")
+    else:
+        try:
+            from gradio.data_classes import SketchpadData  # type: ignore
+        except Exception:
+            SketchpadData = None
+
+        if SketchpadData is not None and isinstance(sam_image, SketchpadData):
+            mask = getattr(sam_image, "mask", None)
+        elif hasattr(sam_image, "mask"):
+            mask = getattr(sam_image, "mask", None)
+
     if mask is None:
-        ia_logging.error("Mask data missing in sam_image")
+        ia_logging.error("Mask data missing in sam_image. Draw on the segmented preview before creating a mask.")
         ret_sel_mask = None if sel_mask is None else gr.update()
         return ret_sel_mask
 


### PR DESCRIPTION
## Summary
- stop treating Segment Anything preview images as mask data so sketching remains required
- add guidance when no sketch mask is supplied, restoring the ability to draw over the segmented preview before mask creation

## Testing
- python -m py_compile scripts/inpaint_anything.py

------
https://chatgpt.com/codex/tasks/task_e_68d7e28f5460832e9ed198e099616802